### PR TITLE
Add support for ESP8266 hardware SPI

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -108,7 +108,11 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
  #if defined(__AVR__) || defined(CORE_TEENSY)
   SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
  #else
-  SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
+    #ifdef ESP8266
+        SPI.setFrequency(8000000L);
+    #else
+        SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
+    #endif
  #endif
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);


### PR DESCRIPTION
As built, the DotStar library is not compatible with the ESP8266 due to how it initializes SPI. This pull request implements the patch described in https://github.com/esp8266/Arduino/issues/415, and has been tested working with the Adafruit Huzzah ESP8266 breakout. To use this, connect CLK to pin #14 and DATA to pin #13 on the Huzzah.
