### PR TITLE
Adding ESP8266 Hardware SPI

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -105,7 +105,7 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   DDRB  |=   _BV(PORTB1) | _BV(PORTB2);  // DO (NOT MOSI) + SCK
 #else
   SPI.begin();
- #if defined(__AVR__) || defined(CORE_TEENSY) || defined(__ARDUINO_ARC__)
+ #if defined(__AVR__) || defined(CORE_TEENSY) || defined(__ARDUINO_ARC__) || defined(ESP8266)
   SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
  #else
   SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due


### PR DESCRIPTION
connect the DotStar to Pin 13 (Data) and Pin 14 (Clock) of an ESP8266 Huzzah Module to use its SPI.

The bitbang approach is ~3 times slower for me (300 Pixels):

```
Adafruit_DotStar strip = Adafruit_DotStar(300, 13, 14, DOTSTAR_BRG);
// strip.show => 14000µs

Adafruit_DotStar strip = Adafruit_DotStar(300, DOTSTAR_BRG);
// strip.show => 4000µs
```

I also experimented with faster Clock Dividers, but for the amount of pixels i'm pushing, a faster clock seems to be a problem. The Pixels started acting weird after 100-150 pixels.
