### PR TITLE
Support for Intel Galileo Gen 2 and Intel Edison. One line of code ch…

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -105,7 +105,7 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   DDRB  |=   _BV(PORTB1) | _BV(PORTB2);  // DO (NOT MOSI) + SCK
 #else
   SPI.begin();
- #if defined(__AVR__) || defined(CORE_TEENSY) || defined(__ARDUINO_ARC__)
+ #if defined(__AVR__) || defined(CORE_TEENSY) || defined(__ARDUINO_ARC__) || defined(__ARDUINO_X86__)
   SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
  #else
   SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due


### PR DESCRIPTION
Intel Galileo 2/Edison support

The architecture defined for Galileo and Edison was added defined(**ARDUINO_X86**). One line of code was changed so that SPI_CLOCK_DIV2 would compile. Before the change Galileo and Edison would not compile because of F_CPU. Our internal DotStar test passes using an 8x8 array. We also tested strand test. Galileo Gen 2, Edison and Arduino101 were tested. Galileo Gen 1 works, but is slow. There might be some pin speed options to improve though.
