### PR TITLE
Move definition of USE_HW_SPI to header file

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -29,8 +29,6 @@
  #include <SPI.h>
 #endif
 
-#define USE_HW_SPI 255 // Assign this to dataPin to indicate 'hard' SPI
-
 // Constructor for hardware SPI -- must connect to MOSI, SCK pins
 Adafruit_DotStar::Adafruit_DotStar(uint16_t n, uint8_t o) :
  numLEDs(n), dataPin(USE_HW_SPI), brightness(0), pixels(NULL),

--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -35,6 +35,8 @@
 #define DOTSTAR_BGR (2 | (1 << 2) | (0 << 4))
 #define DOTSTAR_MONO 0 // Single-color strip WIP DO NOT USE YET
 
+#define USE_HW_SPI 255 // Assign this to dataPin to indicate 'hard' SPI
+
 class Adafruit_DotStar {
 
  public:


### PR DESCRIPTION
This just moves the definition of USE_HW_SPI from the implementation to the header file, so that code that calls the library can use a symbolic value instead of the magic number 255. I guess it might generate warnings in code that redefines the constant for its own use; I'm not sure how (or if) you set warning options in this Arduino business. I can't see how it would actually make any working code malfunction.

Abstraction is good.