### PR TITLE
Updated to use SPI_Master.h to compile for NRF52

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -25,7 +25,11 @@
   ------------------------------------------------------------------------*/
 
 #include "Adafruit_DotStar.h"
-#if !defined(__AVR_ATtiny85__)
+#if NRF52
+  // e.g. RedBear Nano v2
+  #include <SPI_Master.h>
+  #define SPI SPI_Master
+#elif !defined(__AVR_ATtiny85__)
  #include <SPI.h>
 #endif
 
@@ -110,12 +114,23 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
  #else
   #ifdef ESP8266
     SPI.setFrequency(8000000L);
+  #elif NRF52
+    // e.g. RedBear Nano v2
+    SPI.setFrequency(SPI_8M); // TODO: is this the right MHz?
   #else
     SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
   #endif
  #endif
-  SPI.setBitOrder(MSBFIRST);
-  SPI.setDataMode(SPI_MODE0);
+ #ifdef NRF52
+  // e.g. RedBear Nano v2
+  SPI.setBitORDER(MSBFIRST);
+  SPI.setSPIMode(SPI_MODE0);
+ #else
+
+ SPI.setBitOrder(MSBFIRST);
+ SPI.setDataMode(SPI_MODE0);
+ #endif
+  
 #endif
 }
 


### PR DESCRIPTION
Updated to use [SPI_Master.h](https://github.com/redbear/nRF5x/blob/341f6adff63fafefc474e927af3af260d3977004/arduino/arduino-1.8.0/hardware/RBL/RBL_nRF52832/libraries/SPI_Master/SPI_Master.h) instead of ```SPI.h``` to compile for **NRF52** devices such as the [RedBear Nano v2](https://github.com/redbear/nRF5x/).

**Scope**
Checks if ```NRF52``` is defined, and then includes ```SPI_Master.h```.
Also adds ```#define SPI SPI_Master``` so that all other code can remain similar.

**Limitations**
Hopefully no new limitations introduced.

**Test**
Tested with [DotStarMatrix](https://github.com/adafruit/Adafruit_DotStarMatrix) library example: [matrixtest](https://github.com/adafruit/Adafruit_DotStarMatrix/blob/master/examples/matrixtest/matrixtest.pde)