### PR TITLE
Added support for passing in a pointer to a SERCOM module

### DIFF
--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -24,6 +24,9 @@
  #include <WProgram.h>
  #include <pins_arduino.h>
 #endif
+#if !defined(__AVR_ATtiny85__)
+ #include <SPI.h>
+#endif
 
 // Color-order flag for LED pixels (optional extra parameter to constructor):
 // Bits 0,1 = R index (0-2), bits 2,3 = G index, bits 4,5 = B index
@@ -39,7 +42,10 @@ class Adafruit_DotStar {
 
  public:
 
+#if (SPI_INTERFACES_COUNT > 0) || !defined(SPI_INTERFACES_COUNT)
     Adafruit_DotStar(uint16_t n, uint8_t o=DOTSTAR_BRG);
+#endif
+    Adafruit_DotStar(uint16_t n, SPIClass* spi, uint8_t o=DOTSTAR_BRG);
     Adafruit_DotStar(uint16_t n, uint8_t d, uint8_t c, uint8_t o=DOTSTAR_BRG);
    ~Adafruit_DotStar(void);
   void
@@ -73,6 +79,8 @@ class Adafruit_DotStar {
     rOffset,                                // Index of red in 3-byte pixel
     gOffset,                                // Index of green byte
     bOffset;                                // Index of blue byte
+  SPIClass*
+    hwSPI;
 #ifdef __AVR__
   uint8_t
     dataPinMask,                            // If soft SPI, data pin bitmask


### PR DESCRIPTION
Allows the SERCOM module to be passed in, rather than always assuming SPI. Tested with an Adafruit Feather M0 Adalogger. See: [Adafruit: Using ATSAMD21 SERCOM for more SPI, I2C and Serial ports](https://learn.adafruit.com/using-atsamd21-sercom-to-add-more-spi-i2c-serial-ports/creating-a-new-spi)

Example usage:
```#include <SPI.h>
#include <Adafruit_DotStar.h>
#include "wiring_private.h"

SPIClass SPI1(&sercom1, 12, 13, 11, SPI_PAD_0_SCK_1, SERCOM_RX_PAD_3);

Adafruit_DotStar dotStarStrip = Adafruit_DotStar(NUMBER_OF_PIXELS, &SPI1, DOTSTAR_BGR);

void setup()
{
	dotStarStrip.begin();
	dotStarStrip.setBrightness(32);
	dotStarStrip.show();

	pinPeripheral(11, PIO_SERCOM);
	pinPeripheral(12, PIO_SERCOM);
	pinPeripheral(13, PIO_SERCOM);
}

void loop()
{
	dotStarStrip.setPixelColor(0, 255, 0, 0);
	dotStarStrip.show();
}
```