### PR TITLE
Adding onboard brightness control for SK9822

### DIFF
--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -46,6 +46,7 @@ class Adafruit_DotStar {
     begin(void),                            // Prime pins/SPI for output
     clear(),                                // Set all pixel data to zero
     setBrightness(uint8_t),                 // Set global brightness 0-255
+    useOnboardBrightness(bool),                  // set use_onboard_brightness flag
     setPixelColor(uint16_t n, uint32_t c),
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b),
     show(void),                             // Issue color data to strip
@@ -71,6 +72,7 @@ class Adafruit_DotStar {
     dataPin,                                // If soft SPI, data pin #
     clockPin,                               // If soft SPI, clock pin #
     brightness,                             // Global brightness setting
+    use_onboard_brightness,                 // Use onboard brightness instead of software scaling
    *pixels,                                 // LED RGB values (3 bytes ea.)
     rOffset,                                // Index of red in 3-byte pixel
     gOffset,                                // Index of green byte


### PR DESCRIPTION
@PaintYourDragon - Great meeting you at the OSH Park #BringAHack after Maker Faire Bay Area!
As discussed, here's the change to support the onboard brightness control for SK9822 LEDs. 
The juicy details of the differences and the unified protocol are here: https://cpldcpu.wordpress.com/2016/12/13/sk9822-a-clone-of-the-apa102/

I noted that there was comments to the affect of onboard brightness control pull requests would not be accepted, but as we discussed this is primarily for the SK9822, though the change does not exclude using it for the APA102 if desired. To that effect I kept the default backwards compatible with the old method and included a new method `useOnboardBrightness(bool)` to enable or disable using the built-in 5-bit control. I've also slightly tweaked the protocol implementation to match the unified protocol discussed in the above linked article.

I've also included updated comments that should help explain these changes and the differences between APA102 and SK9822. Using the above method to enable/disable was just what I came up with on the spot, but if you have another thought for how you would like this handled, I'm happy to oblige any requested changes.