### PR TITLE
Shift

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -302,6 +302,22 @@ void Adafruit_DotStar::setPixelColor(uint16_t n, uint32_t c) {
   }
 }
 
+void Adafruit_DotStar::shift() {
+  memmove(&pixels[3], &pixels[0], 3 * (numLEDs - 1) * sizeof(uint8_t));
+}
+
+// Shift all pixels, then set pixel 0 color, separate R,G,B values (0-255 ea.)
+void Adafruit_DotStar::shift(uint8_t r, uint8_t g, uint8_t b) {
+  shift();
+  setPixelColor(0, r, g, b);
+}
+
+// Shift all pixels, then set pixel 0 color, 'packed' RGB value (0x000000 - 0xFFFFFF)
+void Adafruit_DotStar::shift(uint32_t c) {
+  shift();
+  setPixelColor(0, c);
+}
+
 // Convert separate R,G,B to packed value
 uint32_t Adafruit_DotStar::Color(uint8_t r, uint8_t g, uint8_t b) {
   return ((uint32_t)r << 16) | ((uint32_t)g << 8) | b;

--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -48,6 +48,8 @@ class Adafruit_DotStar {
     setBrightness(uint8_t),                 // Set global brightness 0-255
     setPixelColor(uint16_t n, uint32_t c),
     setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b),
+    shift(uint32_t c),                      // Shift all pixels and set pixel 0
+    shift(uint8_t r, uint8_t g, uint8_t b),
     show(void),                             // Issue color data to strip
     updatePins(void),                       // Change pin assignments (HW)
     updatePins(uint8_t d, uint8_t c),       // Change pin assignments (SW)
@@ -84,6 +86,7 @@ class Adafruit_DotStar {
    *clockPort;                              // If soft SPI, clock PORT
 #endif
   void
+    shift(),                                // Shift all pixels one spot
     hw_spi_init(void),                      // Start hardware SPI
     hw_spi_end(void),                       // Stop hardware SPI
     sw_spi_init(void),                      // Start bitbang SPI

--- a/examples/strandshifttest/strandshifttest.ino
+++ b/examples/strandshifttest/strandshifttest.ino
@@ -1,0 +1,59 @@
+// Simple strand test for Adafruit Dot Star RGB LED strip.
+// This is a basic diagnostic tool, NOT a graphics demo...helps confirm
+// correct wiring and tests each pixel's ability to display red, green
+// and blue and to forward data down the line.  By limiting the number
+// and color of LEDs, it's reasonably safe to power a couple meters off
+// the Arduino's 5V pin.  DON'T try that with other code!
+
+#include <Adafruit_DotStar.h>
+// Because conditional #includes don't work w/Arduino sketches...
+#include <SPI.h>         // COMMENT OUT THIS LINE FOR GEMMA OR TRINKET
+//#include <avr/power.h> // ENABLE THIS LINE FOR GEMMA OR TRINKET
+
+#define NUMPIXELS 30 // Number of LEDs in strip
+
+// Here's how to control the LEDs from any two pins:
+#define DATAPIN    4
+#define CLOCKPIN   5
+Adafruit_DotStar strip = Adafruit_DotStar(
+  NUMPIXELS, DATAPIN, CLOCKPIN, DOTSTAR_BRG);
+// The last parameter is optional -- this is the color data order of the
+// DotStar strip, which has changed over time in different production runs.
+// Your code just uses R,G,B colors, the library then reassigns as needed.
+// Default is DOTSTAR_BRG, so change this if you have an earlier strip.
+
+// Hardware SPI is a little faster, but must be wired to specific pins
+// (Arduino Uno = pin 11 for data, 13 for clock, other boards are different).
+//Adafruit_DotStar strip = Adafruit_DotStar(NUMPIXELS, DOTSTAR_BRG);
+
+void setup() {
+
+#if defined(__AVR_ATtiny85__) && (F_CPU == 16000000L)
+  clock_prescale_set(clock_div_1); // Enable 16 MHz on Trinket
+#endif
+
+  strip.begin(); // Initialize pins for output
+  strip.show();  // Turn all LEDs off ASAP
+}
+
+// Runs 10 LEDs at a time along strip, cycling through red, green and blue.
+// This requires about 200 mA for all the 'on' pixels + 1 mA per 'off' pixel.
+
+int      head  = 0;        // Index of first 'on' pixel
+int      length = 10;      // Length of the strand
+uint32_t color = 0xFF0000; // 'On' color (starts red)
+
+void loop() {
+  if (head < length)
+    strip.shift(color);
+  else
+    strip.shift(0x000000);
+  strip.show();
+  delay(20);
+
+  if(++head >= NUMPIXELS) {         // Increment head index.  Off end of strip?
+    head = 0;                       //  Yes, reset head index to start
+    if((color >>= 8) == 0)          //  Next color (R->G->B) ... past blue now?
+      color = 0xFF0000;             //   Yes, reset to red
+  }
+}


### PR DESCRIPTION
This pull request adds a method to the Adafruit_DotStar class to push all pixels
one position towards the end, and then set the color of the first pixel.

Three prototypes are added to Adafruit_DotStar.h. 
Two public methods :
    shift(uint32_t c),                      
    shift(uint8_t r, uint8_t g, uint8_t b),
One private :
    shift(),

All three methods are implemented in Adafruit_DotStar.cpp

Known limitation : I haven't accounted for monochrome strips, as it's still a work in progress. Apart from that, none that I can think of.

I've provided a new example, strandshifttest. It's basically the strandtest, modified to use the new shift method.