### PR TITLE
SPI: Document possibility of faster clock speeds

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -167,6 +167,10 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   DDRB  |=   _BV(PORTB1) | _BV(PORTB2);  // DO (NOT MOSI) + SCK
 #elif (SPI_INTERFACES_COUNT > 0) || !defined(SPI_INTERFACES_COUNT)
   SPI.begin();
+  // Hardware SPI clock speeds are chosen to run at roughly 1-8 MHz for most
+  // boards, providing a slower but more reliable experience by default.  If
+  // you want faster LED updates, experiment with the clock speeds to find
+  // what works best with your particular setup.
  #if defined(__AVR__) || defined(CORE_TEENSY) || defined(__ARDUINO_ARC__) || defined(__ARDUINO_X86__)
   SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
  #else


### PR DESCRIPTION
## In brief
* Document the option of faster hardware SPI clock speeds
  * Mention risks of unreliable results
  * Fixes [issue #31](https://github.com/adafruit/Adafruit_DotStar/issues/31 )

## Details

In `Adafruit_DotStar::hw_spi_init()`, document the possibility of specifying faster hardware SPI clock speeds to provide faster LED updates at the risk of unreliable results.

The comment is placed after the `__AVR_ATtiny85__` code as that does not appear to have a formal SPI interface.  If the comment needs moved or adjusted, I'll gladly change it.

*Skipping in-depth analysis as this is a documentation-only change.*