### PR TITLE
add no-ops in software bit bashing for fast processors

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -271,7 +271,17 @@ void Adafruit_DotStar::sw_spi_out(uint8_t n) {
     if(n & 0x80) digitalWrite(dataPin, HIGH);
     else         digitalWrite(dataPin, LOW);
     digitalWrite(clockPin, HIGH);
+#if F_CPU >= 48000000
+    __asm__ volatile(
+    "nop \n nop"
+    );
+#endif
     digitalWrite(clockPin, LOW);
+#if F_CPU >= 48000000
+    __asm__ volatile(
+    "nop \n nop"
+    );
+#endif
 #endif
   }
 }


### PR DESCRIPTION
This change simply adds no-ops in assembly for software-based switching for CPUs with a frequency greater than or equal to 48 Mhz. In testing with a teensy (72 Mhz) I found that without these no-ops, the output pins had no time to stabilize to output voltages.