### PR TITLE
REQ:  Please Add Support For MKR-RGB and Portenta H7

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -246,8 +246,8 @@ void Adafruit_DotStar::sw_spi_init(void) {
   @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
 */
 void Adafruit_DotStar::sw_spi_end() {
-  pinMode(dataPin, INPUT);		// agrees with pinMap but can't be assumed.
-  pinMode(clockPin, INPUT);		// agrees with pinMap but can't be assumed.
+  pinMode(dataPin, INPUT);		// agrees with pinMap but can't be assumed (Portenta H7 comment).
+  pinMode(clockPin, INPUT);		// agrees with pinMap but can't be assumed (Portenta H7 comment).
 }
 
 #ifdef __AVR_ATtiny85__

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -92,7 +92,8 @@ Adafruit_DotStar::~Adafruit_DotStar(void) {
     hw_spi_end();
   else
 	  sw_spi_end();
-#else
+#endif  
+#ifdef PORTENTA_H7
    sw_spi_end();
 #endif
 }
@@ -107,7 +108,8 @@ void Adafruit_DotStar::begin(void) {
     hw_spi_init();
   else
 	  sw_spi_init();
-#else
+#endif
+#ifdef PORTENTA_H7	
 	sw_spi_init();
 #endif
 }

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -86,11 +86,15 @@ Adafruit_DotStar::Adafruit_DotStar(uint16_t n, uint8_t data, uint8_t clock,
            back to INPUT.
 */
 Adafruit_DotStar::~Adafruit_DotStar(void) {
-  free(pixels);
+   free(pixels);
+#ifndef PORTENTA_H7
   if (dataPin == USE_HW_SPI)
     hw_spi_end();
   else
-    sw_spi_end();
+	  sw_spi_end();
+#else
+   sw_spi_end();
+#endif
 }
 
 /*!
@@ -98,10 +102,14 @@ Adafruit_DotStar::~Adafruit_DotStar(void) {
            to outputs and initializes hardware SPI if necessary.
 */
 void Adafruit_DotStar::begin(void) {
+#ifndef PORTENTA_H7	
   if (dataPin == USE_HW_SPI)
     hw_spi_init();
   else
-    sw_spi_init();
+	  sw_spi_init();
+#else
+	sw_spi_init();
+#endif
 }
 
 // Pins may be reassigned post-begin(), so a sketch can store hardware
@@ -116,9 +124,12 @@ void Adafruit_DotStar::begin(void) {
            continue to be used.
 */
 void Adafruit_DotStar::updatePins(void) {
+	
   sw_spi_end();
+#ifndef PORTENTA_H7		
   dataPin = USE_HW_SPI;
   hw_spi_init();
+#endif
 }
 
 /*!
@@ -129,7 +140,9 @@ void Adafruit_DotStar::updatePins(void) {
   @param   clock  Arduino pin number for clock out.
 */
 void Adafruit_DotStar::updatePins(uint8_t data, uint8_t clock) {
-  hw_spi_end();
+#ifndef PORTENTA_H7		
+	hw_spi_end();
+#endif	
   dataPin = data;
   clockPin = clock;
   sw_spi_init();
@@ -186,11 +199,15 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
   SPI.endTransaction();
 #else
+#ifndef PORTENTA_H7	  
   SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
 #endif
 #endif
+#endif
+#ifndef PORTENTA_H7	  
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);
+#endif  
 #endif
 }
 
@@ -229,8 +246,8 @@ void Adafruit_DotStar::sw_spi_init(void) {
   @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
 */
 void Adafruit_DotStar::sw_spi_end() {
-  pinMode(dataPin, INPUT);
-  pinMode(clockPin, INPUT);
+  pinMode(dataPin, INPUT);		// agrees with pinMap but can't be assumed.
+  pinMode(clockPin, INPUT);		// agrees with pinMap but can't be assumed.
 }
 
 #ifdef __AVR_ATtiny85__

--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -28,7 +28,8 @@
 #include <pins_arduino.h>
 #endif
 
-#define PORTENTA_H7	// STM32H747xI
+// Uncomment the following to use the Portanta-H7 with the MKR-RGB Shield
+// #define PORTENTA_H7	// STM32H747xI
 
 // Color-order flag for LED pixels (optional extra parameter to constructor):
 // Bits 0,1 = R index (0-2), bits 2,3 = G index, bits 4,5 = B index

--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -28,6 +28,8 @@
 #include <pins_arduino.h>
 #endif
 
+#define PORTENTA_H7	// STM32H747xI
+
 // Color-order flag for LED pixels (optional extra parameter to constructor):
 // Bits 0,1 = R index (0-2), bits 2,3 = G index, bits 4,5 = B index
 #define DOTSTAR_RGB (0 | (1 << 2) | (2 << 4)) ///< Transmit as R,G,B

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Adafruit DotStar [![Build Status](https://github.com/adafruit/Adafruit_DotStar/workflows/Arduino%20Library%20CI/badge.svg)](https://github.com/adafruit/Adafruit_DotStar/actions)
 
 Arduino library for controlling two-wire-based LED pixels and strips such as Adafruit DotStar LEDs and other APA102-compatible devices.
+
+Update:  This has been updated to work with the MKR-RGB Shield and the Portanta_H7.  A jumper must be placed from A3->A5.


### PR DESCRIPTION
Note - example in DotStarMatrix will demonstrate the changes - so, this in addition to the PR in the DotStarMatrix PR are necessary.

REQ: Please Add Support for the MRK-RGB Shield and the Portenta_H7.  A jumper must be placed from A3->A5 when using the MRK-RGB shield on the Portenta H7.

List of changes:
The MRK-RGB shield has to used in 'bit-bang' mode to work on the Portenta H7 and one jumper must be added - the 
A3 pin must be jumpered to A5.  It's a relatively easy change to be able to use the shield on the H7.  Yes, it's a one-off but 
I must admit I like to use that shield on the H7.  And, you can't have too many graphics libs, right?

In Adafruit_Dotstar.h:
added:
#define PORTENTA_H7	// STM32H747xI
In Adafruit_Dotstar.cpp:
added:
#ifndef PORTENTA_H7 'wrapper' to force use of software spi (a.k.a. bit-bang mode).

Readme.md:
Updated to summarize changes made.

To run as-is (before this update) - just comment out the
#define PORTENTA_H7	// STM32H747xI
in Adafruit_Dotstar.h.

This update is also demonstrated in a subsequent PR in the Adafruit_DotStarMatrix library:
..\examples\dotstar_wing\dotstar_win.ino has been updated to allow use of the MKR-RGB
shield on the Portenta H7.
