### PR TITLE
REQ: Please Add Support For MKR-RGB and Portenta H7 

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -247,7 +247,7 @@ void Adafruit_DotStar::sw_spi_init(void) {
 /*!
   @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
 */
-void Adafruit_DotStar::sw_spi_end() {
+void Adafruit_DotStar::sw_spi_end(void) {
 	pinMode(dataPin, INPUT);
 	// agrees with pinMap but can't be assumed (Portenta H7 comment).
 	pinMode(clockPin, INPUT);
@@ -415,7 +415,7 @@ void Adafruit_DotStar::show(void) {
 /*!
   @brief   Fill the whole DotStar strip with 0 / black / off.
 */
-void Adafruit_DotStar::clear() {
+void Adafruit_DotStar::clear(void) {
   memset(pixels, 0,
          (rOffset == gOffset) ? numLEDs + ((numLEDs + 3) / 4)
                               : // MONO: 10 bits/pixel

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -246,8 +246,8 @@ void Adafruit_DotStar::sw_spi_init(void) {
   @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
 */
 void Adafruit_DotStar::sw_spi_end() {
-  pinMode(dataPin, INPUT);		// agrees with pinMap but can't be assumed.
-  pinMode(clockPin, INPUT);		// agrees with pinMap but can't be assumed.
+  pinMode(dataPin, INPUT);		// agrees with pinMap but can't be assumed (Portenta H7 comment).
+  pinMode(clockPin, INPUT);		// agrees with pinMap but can't be assumed (Portenta H7 comment).
 }
 
 #ifdef __AVR_ATtiny85__

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -653,9 +653,7 @@ uint32_t Adafruit_DotStar::gamma32(uint32_t x) {
 */
 void Adafruit_DotStar::sw_spi_end(void) {
 	pinMode(dataPin, INPUT);
-	// agrees with pinMap but can't be assumed (Portenta H7 comment).
 	pinMode(clockPin, INPUT);
-	// agrees with pinMap but can't be assumed (Portenta H7 comment).
 }
 
 

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -193,19 +193,23 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
 #if defined(__AVR__) || defined(CORE_TEENSY) || defined(__ARDUINO_ARC__) ||    \
     defined(__ARDUINO_X86__)
   SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
-#elif defined(ESP8266)
+#else
+#if defined(ESP8266)
   SPI.setFrequency(8000000L);
 #elif defined(PIC32)
   // Use begin/end transaction to set SPI clock rate
   SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
   SPI.endTransaction();
-#elif !defined(PORTENTA_H7)       
+#else
+#if !defined(PORTENTA_H7)       
   SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
 #endif
 #endif
+#endif  
 #if !defined(PORTENTA_H7)       
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);
+#endif
 #endif  
 }
 

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -92,7 +92,8 @@ Adafruit_DotStar::~Adafruit_DotStar(void) {
     hw_spi_end();
   else
 	  sw_spi_end();
-#else
+#endif  
+#ifdef PORTENTA_H7
    sw_spi_end();
 #endif
 }
@@ -107,7 +108,8 @@ void Adafruit_DotStar::begin(void) {
     hw_spi_init();
   else
 	  sw_spi_init();
-#else
+#endif
+#ifdef PORTENTA_H7	
 	sw_spi_init();
 #endif
 }

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -272,15 +272,6 @@ static void spi_out(uint8_t n) { // Clock out one byte
 #endif
 
 
-/*!
-  @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
-*/
-void Adafruit_DotStar::sw_spi_end(void) {
-	pinMode(dataPin, INPUT);
-	// agrees with pinMap but can't be assumed (Portenta H7 comment).
-	pinMode(clockPin, INPUT);
-	// agrees with pinMap but can't be assumed (Portenta H7 comment).
-}
 
 /*!
   @brief   Soft (bitbang) SPI write.
@@ -655,6 +646,16 @@ uint32_t Adafruit_DotStar::gamma32(uint32_t x) {
   for (uint8_t i = 0; i < 4; i++)
     y[i] = gamma8(y[i]);
   return x; // Packed 32-bit return
+}
+
+/*!
+  @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
+*/
+void Adafruit_DotStar::sw_spi_end(void) {
+	pinMode(dataPin, INPUT);
+	// agrees with pinMap but can't be assumed (Portenta H7 comment).
+	pinMode(clockPin, INPUT);
+	// agrees with pinMap but can't be assumed (Portenta H7 comment).
 }
 
 

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -86,15 +86,15 @@ Adafruit_DotStar::Adafruit_DotStar(uint16_t n, uint8_t data, uint8_t clock,
            back to INPUT.
 */
 Adafruit_DotStar::~Adafruit_DotStar(void) {
-   free(pixels);
+  free(pixels);
 #if !defined(PORTENTA_H7)
   if (dataPin == USE_HW_SPI)
     hw_spi_end();
   else
-          sw_spi_end();
-#endif  
+    sw_spi_end();
+#endif
 #if defined(PORTENTA_H7)
-   sw_spi_end();
+  sw_spi_end();
 #endif
 }
 
@@ -103,14 +103,14 @@ Adafruit_DotStar::~Adafruit_DotStar(void) {
            to outputs and initializes hardware SPI if necessary.
 */
 void Adafruit_DotStar::begin(void) {
-#if !defined(PORTENTA_H7)     
+#if !defined(PORTENTA_H7)
   if (dataPin == USE_HW_SPI)
     hw_spi_init();
   else
-          sw_spi_init();
+    sw_spi_init();
 #endif
-#if defined(PORTENTA_H7)      
-        sw_spi_init();
+#if defined(PORTENTA_H7)
+  sw_spi_init();
 #endif
 }
 
@@ -126,9 +126,9 @@ void Adafruit_DotStar::begin(void) {
            continue to be used.
 */
 void Adafruit_DotStar::updatePins(void) {
-        
+
   sw_spi_end();
-#if !defined(PORTENTA_H7)             
+#if !defined(PORTENTA_H7)
   dataPin = USE_HW_SPI;
   hw_spi_init();
 #endif
@@ -142,9 +142,9 @@ void Adafruit_DotStar::updatePins(void) {
   @param   clock  Arduino pin number for clock out.
 */
 void Adafruit_DotStar::updatePins(uint8_t data, uint8_t clock) {
-#if !defined(PORTENTA_H7)             
-        hw_spi_end();
-#endif  
+#if !defined(PORTENTA_H7)
+  hw_spi_end();
+#endif
   dataPin = data;
   clockPin = clock;
   sw_spi_init();
@@ -201,16 +201,16 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
   SPI.endTransaction();
 #else
-#if !defined(PORTENTA_H7)       
+#if !defined(PORTENTA_H7)
   SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
 #endif
 #endif
-#endif  
-#if !defined(PORTENTA_H7)       
+#endif
+#if !defined(PORTENTA_H7)
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);
 #endif
-#endif  
+#endif
 }
 
 /*!
@@ -244,16 +244,26 @@ void Adafruit_DotStar::sw_spi_init(void) {
 #endif
 }
 
+/*!
+  @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
+*/
+void Adafruit_DotStar::sw_spi_end(void) {
+  pinMode(dataPin, INPUT);  // pinPeripheral() should be called to make sure ok
+                            // in map file (H7)
+  pinMode(clockPin, INPUT); // pinPeripheral() should be called to make sure ok
+                            // in map file (H7)
+}
+
 #if defined(__AVR_ATtiny85__)
 // Teensy/Gemma-specific stuff for hardware-half-assisted SPI
-#define SPIBIT  \
-    USICR = ((1 << USIWM0) | (1 << USITC)); \
-    USICR =  \
-	((1 << USIWM0) | (1 << USITC) | (1 << USICLK)); // Clock bit tick, tock
+#define SPIBIT                                                                 \
+  USICR = ((1 << USIWM0) | (1 << USITC));                                      \
+  USICR =                                                                      \
+      ((1 << USIWM0) | (1 << USITC) | (1 << USICLK)); // Clock bit tick, tock
 
 static void spi_out(uint8_t n) { // Clock out one byte
-	USIDR = n;
-	SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT
+  USIDR = n;
+  SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT
 }
 
 #elif (SPI_INTERFACES_COUNT > 0) || !defined(SPI_INTERFACES_COUNT)
@@ -270,8 +280,6 @@ static void spi_out(uint8_t n) { // Clock out one byte
 #define spi_out(n) sw_spi_out(n)
 
 #endif
-
-
 
 /*!
   @brief   Soft (bitbang) SPI write.
@@ -647,13 +655,3 @@ uint32_t Adafruit_DotStar::gamma32(uint32_t x) {
     y[i] = gamma8(y[i]);
   return x; // Packed 32-bit return
 }
-
-/*!
-  @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
-*/
-void Adafruit_DotStar::sw_spi_end(void) {
-	pinMode(dataPin, INPUT);
-	pinMode(clockPin, INPUT);
-}
-
-

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -86,11 +86,15 @@ Adafruit_DotStar::Adafruit_DotStar(uint16_t n, uint8_t data, uint8_t clock,
            back to INPUT.
 */
 Adafruit_DotStar::~Adafruit_DotStar(void) {
-  free(pixels);
+   free(pixels);
+#ifndef PORTENTA_H7
   if (dataPin == USE_HW_SPI)
     hw_spi_end();
   else
-    sw_spi_end();
+	  sw_spi_end();
+#else
+   sw_spi_end();
+#endif
 }
 
 /*!
@@ -98,10 +102,14 @@ Adafruit_DotStar::~Adafruit_DotStar(void) {
            to outputs and initializes hardware SPI if necessary.
 */
 void Adafruit_DotStar::begin(void) {
+#ifndef PORTENTA_H7	
   if (dataPin == USE_HW_SPI)
     hw_spi_init();
   else
-    sw_spi_init();
+	  sw_spi_init();
+#else
+	sw_spi_init();
+#endif
 }
 
 // Pins may be reassigned post-begin(), so a sketch can store hardware
@@ -116,9 +124,12 @@ void Adafruit_DotStar::begin(void) {
            continue to be used.
 */
 void Adafruit_DotStar::updatePins(void) {
+	
   sw_spi_end();
+#ifndef PORTENTA_H7		
   dataPin = USE_HW_SPI;
   hw_spi_init();
+#endif
 }
 
 /*!
@@ -129,7 +140,9 @@ void Adafruit_DotStar::updatePins(void) {
   @param   clock  Arduino pin number for clock out.
 */
 void Adafruit_DotStar::updatePins(uint8_t data, uint8_t clock) {
-  hw_spi_end();
+#ifndef PORTENTA_H7		
+	hw_spi_end();
+#endif	
   dataPin = data;
   clockPin = clock;
   sw_spi_init();
@@ -186,11 +199,15 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
   SPI.endTransaction();
 #else
+#ifndef PORTENTA_H7	  
   SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
 #endif
 #endif
+#endif
+#ifndef PORTENTA_H7	  
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);
+#endif  
 #endif
 }
 
@@ -229,8 +246,8 @@ void Adafruit_DotStar::sw_spi_init(void) {
   @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
 */
 void Adafruit_DotStar::sw_spi_end() {
-  pinMode(dataPin, INPUT);
-  pinMode(clockPin, INPUT);
+  pinMode(dataPin, INPUT);		// agrees with pinMap but can't be assumed.
+  pinMode(clockPin, INPUT);		// agrees with pinMap but can't be assumed.
 }
 
 #ifdef __AVR_ATtiny85__

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -91,7 +91,7 @@ Adafruit_DotStar::~Adafruit_DotStar(void) {
   if (dataPin == USE_HW_SPI)
     hw_spi_end();
   else
-	  sw_spi_end();
+          sw_spi_end();
 #endif  
 #ifdef PORTENTA_H7
    sw_spi_end();
@@ -103,14 +103,14 @@ Adafruit_DotStar::~Adafruit_DotStar(void) {
            to outputs and initializes hardware SPI if necessary.
 */
 void Adafruit_DotStar::begin(void) {
-#ifndef PORTENTA_H7	
+#ifndef PORTENTA_H7     
   if (dataPin == USE_HW_SPI)
     hw_spi_init();
   else
-	  sw_spi_init();
+          sw_spi_init();
 #endif
-#ifdef PORTENTA_H7	
-	sw_spi_init();
+#ifdef PORTENTA_H7      
+        sw_spi_init();
 #endif
 }
 
@@ -126,9 +126,9 @@ void Adafruit_DotStar::begin(void) {
            continue to be used.
 */
 void Adafruit_DotStar::updatePins(void) {
-	
+        
   sw_spi_end();
-#ifndef PORTENTA_H7		
+#ifndef PORTENTA_H7             
   dataPin = USE_HW_SPI;
   hw_spi_init();
 #endif
@@ -142,9 +142,9 @@ void Adafruit_DotStar::updatePins(void) {
   @param   clock  Arduino pin number for clock out.
 */
 void Adafruit_DotStar::updatePins(uint8_t data, uint8_t clock) {
-#ifndef PORTENTA_H7		
-	hw_spi_end();
-#endif	
+#ifndef PORTENTA_H7             
+        hw_spi_end();
+#endif  
   dataPin = data;
   clockPin = clock;
   sw_spi_init();
@@ -201,12 +201,12 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
   SPI.endTransaction();
 #else
-#ifndef PORTENTA_H7	  
+#ifndef PORTENTA_H7       
   SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
 #endif
 #endif
 #endif
-#ifndef PORTENTA_H7	  
+#ifndef PORTENTA_H7       
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);
 #endif  
@@ -248,8 +248,8 @@ void Adafruit_DotStar::sw_spi_init(void) {
   @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
 */
 void Adafruit_DotStar::sw_spi_end() {
-  pinMode(dataPin, INPUT);		// agrees with pinMap but can't be assumed (Portenta H7 comment).
-  pinMode(clockPin, INPUT);		// agrees with pinMap but can't be assumed (Portenta H7 comment).
+  pinMode(dataPin, INPUT);              // agrees with pinMap but can't be assumed (Portenta H7 comment).
+  pinMode(clockPin, INPUT);             // agrees with pinMap but can't be assumed (Portenta H7 comment).
 }
 
 #ifdef __AVR_ATtiny85__

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -181,7 +181,7 @@ void Adafruit_DotStar::updateLength(uint16_t n) {
            some rewriting to correctly share the SPI bus with other devices.
 */
 void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
-#if defined (__AVR_ATtiny85__)
+#if defined(__AVR_ATtiny85__)
   PORTB &= ~(_BV(PORTB1) | _BV(PORTB2)); // Outputs
   DDRB |= _BV(PORTB1) | _BV(PORTB2);     // DO (NOT MOSI) + SCK
 #elif (SPI_INTERFACES_COUNT > 0) || !defined(SPI_INTERFACES_COUNT)
@@ -248,8 +248,10 @@ void Adafruit_DotStar::sw_spi_init(void) {
   @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
 */
 void Adafruit_DotStar::sw_spi_end() {
-  pinMode(dataPin, INPUT);              // agrees with pinMap but can't be assumed (Portenta H7 comment).
-  pinMode(clockPin, INPUT);             // agrees with pinMap but can't be assumed (Portenta H7 comment).
+	pinMode(dataPin, INPUT);
+	// agrees with pinMap but can't be assumed (Portenta H7 comment).
+	pinMode(clockPin, INPUT);
+	// agrees with pinMap but can't be assumed (Portenta H7 comment).
 }
 
 #if defined(__AVR_ATtiny85__)

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -87,13 +87,13 @@ Adafruit_DotStar::Adafruit_DotStar(uint16_t n, uint8_t data, uint8_t clock,
 */
 Adafruit_DotStar::~Adafruit_DotStar(void) {
    free(pixels);
-#ifndef PORTENTA_H7
+#if !defined(PORTENTA_H7)
   if (dataPin == USE_HW_SPI)
     hw_spi_end();
   else
           sw_spi_end();
 #endif  
-#ifdef PORTENTA_H7
+#if defined(PORTENTA_H7)
    sw_spi_end();
 #endif
 }
@@ -103,13 +103,13 @@ Adafruit_DotStar::~Adafruit_DotStar(void) {
            to outputs and initializes hardware SPI if necessary.
 */
 void Adafruit_DotStar::begin(void) {
-#ifndef PORTENTA_H7     
+#if !defined(PORTENTA_H7)     
   if (dataPin == USE_HW_SPI)
     hw_spi_init();
   else
           sw_spi_init();
 #endif
-#ifdef PORTENTA_H7      
+#if defined(PORTENTA_H7)      
         sw_spi_init();
 #endif
 }
@@ -128,7 +128,7 @@ void Adafruit_DotStar::begin(void) {
 void Adafruit_DotStar::updatePins(void) {
         
   sw_spi_end();
-#ifndef PORTENTA_H7             
+#if !defined(PORTENTA_H7)             
   dataPin = USE_HW_SPI;
   hw_spi_init();
 #endif
@@ -142,7 +142,7 @@ void Adafruit_DotStar::updatePins(void) {
   @param   clock  Arduino pin number for clock out.
 */
 void Adafruit_DotStar::updatePins(uint8_t data, uint8_t clock) {
-#ifndef PORTENTA_H7             
+#if !defined(PORTENTA_H7)             
         hw_spi_end();
 #endif  
   dataPin = data;
@@ -201,12 +201,12 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
   SPI.endTransaction();
 #else
-#ifndef PORTENTA_H7       
+#if !defined(PORTENTA_H7)       
   SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
 #endif
 #endif
 #endif
-#ifndef PORTENTA_H7       
+#if !defined(PORTENTA_H7)       
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);
 #endif  

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -193,8 +193,7 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
 #if defined(__AVR__) || defined(CORE_TEENSY) || defined(__ARDUINO_ARC__) ||    \
     defined(__ARDUINO_X86__)
   SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
-#else
-#if defined(ESP8266)
+#elif defined(ESP8266)
   SPI.setFrequency(8000000L);
 #elif defined(PIC32)
   // Use begin/end transaction to set SPI clock rate
@@ -202,7 +201,6 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   SPI.endTransaction();
 #elif !defined(PORTENTA_H7)       
   SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
-#endif
 #endif
 #endif
 #if !defined(PORTENTA_H7)       

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -200,8 +200,7 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   // Use begin/end transaction to set SPI clock rate
   SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
   SPI.endTransaction();
-#else
-#if !defined(PORTENTA_H7)       
+#elif !defined(PORTENTA_H7)       
   SPI.setClockDivider((F_CPU + 4000000L) / 8000000L); // 8-ish MHz on Due
 #endif
 #endif
@@ -210,7 +209,6 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);
 #endif  
-#endif
 }
 
 /*!

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -244,28 +244,16 @@ void Adafruit_DotStar::sw_spi_init(void) {
 #endif
 }
 
-/*!
-  @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
-*/
-void Adafruit_DotStar::sw_spi_end(void) {
-	pinMode(dataPin, INPUT);
-	// agrees with pinMap but can't be assumed (Portenta H7 comment).
-	pinMode(clockPin, INPUT);
-	// agrees with pinMap but can't be assumed (Portenta H7 comment).
-}
-
 #if defined(__AVR_ATtiny85__)
-
 // Teensy/Gemma-specific stuff for hardware-half-assisted SPI
-
-#define SPIBIT                                                                 \
-  USICR = ((1 << USIWM0) | (1 << USITC));                                      \
-  USICR =                                                                      \
-      ((1 << USIWM0) | (1 << USITC) | (1 << USICLK)); // Clock bit tick, tock
+#define SPIBIT  \
+    USICR = ((1 << USIWM0) | (1 << USITC)); \
+    USICR =  \
+	((1 << USIWM0) | (1 << USITC) | (1 << USICLK)); // Clock bit tick, tock
 
 static void spi_out(uint8_t n) { // Clock out one byte
-  USIDR = n;
-  SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT
+	USIDR = n;
+	SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT SPIBIT
 }
 
 #elif (SPI_INTERFACES_COUNT > 0) || !defined(SPI_INTERFACES_COUNT)
@@ -282,6 +270,17 @@ static void spi_out(uint8_t n) { // Clock out one byte
 #define spi_out(n) sw_spi_out(n)
 
 #endif
+
+
+/*!
+  @brief   Stop 'soft' (bitbang) SPI. Data and clock pins are set to inputs.
+*/
+void Adafruit_DotStar::sw_spi_end(void) {
+	pinMode(dataPin, INPUT);
+	// agrees with pinMap but can't be assumed (Portenta H7 comment).
+	pinMode(clockPin, INPUT);
+	// agrees with pinMap but can't be assumed (Portenta H7 comment).
+}
 
 /*!
   @brief   Soft (bitbang) SPI write.
@@ -657,3 +656,5 @@ uint32_t Adafruit_DotStar::gamma32(uint32_t x) {
     y[i] = gamma8(y[i]);
   return x; // Packed 32-bit return
 }
+
+

--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -181,7 +181,7 @@ void Adafruit_DotStar::updateLength(uint16_t n) {
            some rewriting to correctly share the SPI bus with other devices.
 */
 void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
-#ifdef __AVR_ATtiny85__
+#if defined (__AVR_ATtiny85__)
   PORTB &= ~(_BV(PORTB1) | _BV(PORTB2)); // Outputs
   DDRB |= _BV(PORTB1) | _BV(PORTB2);     // DO (NOT MOSI) + SCK
 #elif (SPI_INTERFACES_COUNT > 0) || !defined(SPI_INTERFACES_COUNT)
@@ -194,7 +194,7 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
     defined(__ARDUINO_X86__)
   SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (6 MHz on Pro Trinket 3V)
 #else
-#ifdef ESP8266
+#if defined(ESP8266)
   SPI.setFrequency(8000000L);
 #elif defined(PIC32)
   // Use begin/end transaction to set SPI clock rate
@@ -217,7 +217,7 @@ void Adafruit_DotStar::hw_spi_init(void) { // Initialize hardware SPI
   @brief   Stop hardware SPI.
 */
 void Adafruit_DotStar::hw_spi_end(void) {
-#ifdef __AVR_ATtiny85__
+#if defined(__AVR_ATtiny85__)
   DDRB &= ~(_BV(PORTB1) | _BV(PORTB2)); // Inputs
 #elif (SPI_INTERFACES_COUNT > 0) || !defined(SPI_INTERFACES_COUNT)
   SPI.end();
@@ -231,7 +231,7 @@ void Adafruit_DotStar::hw_spi_end(void) {
 void Adafruit_DotStar::sw_spi_init(void) {
   pinMode(dataPin, OUTPUT);
   pinMode(clockPin, OUTPUT);
-#ifdef __AVR__
+#if defined(__AVR__)
   dataPort = portOutputRegister(digitalPinToPort(dataPin));
   clockPort = portOutputRegister(digitalPinToPort(clockPin));
   dataPinMask = digitalPinToBitMask(dataPin);
@@ -252,7 +252,7 @@ void Adafruit_DotStar::sw_spi_end() {
   pinMode(clockPin, INPUT);             // agrees with pinMap but can't be assumed (Portenta H7 comment).
 }
 
-#ifdef __AVR_ATtiny85__
+#if defined(__AVR_ATtiny85__)
 
 // Teensy/Gemma-specific stuff for hardware-half-assisted SPI
 
@@ -287,7 +287,7 @@ static void spi_out(uint8_t n) { // Clock out one byte
 */
 void Adafruit_DotStar::sw_spi_out(uint8_t n) {
   for (uint8_t i = 8; i--; n <<= 1) {
-#ifdef __AVR__
+#if defined(__AVR__)
     if (n & 0x80)
       *dataPort |= dataPinMask;
     else
@@ -341,7 +341,7 @@ void Adafruit_DotStar::show(void) {
 
     // TO DO: modernize this for SPI transactions
 
-#ifdef SPI_PIPELINE
+#if defined(SPI_PIPELINE)
     uint8_t next;
     for (i = 0; i < 3; i++)
       spi_out(0x00); // First 3 start-frame bytes

--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -29,7 +29,7 @@
 #endif
 
 // Uncomment the following to use the Portanta-H7 with the MKR-RGB Shield
-// #define PORTENTA_H7	// STM32H747xI
+// #define PORTENTA_H7  // STM32H747xI
 
 // Color-order flag for LED pixels (optional extra parameter to constructor):
 // Bits 0,1 = R index (0-2), bits 2,3 = G index, bits 4,5 = B index

--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -28,7 +28,8 @@
 #include <pins_arduino.h>
 #endif
 
-#define PORTENTA_H7	// STM32H747xI
+// Uncomment the following to use the Portanta-H7 with the MKR-RGB Shield
+// #define PORTENTA_H7	// STM32H747xI
 
 // Color-order flag for LED pixels (optional extra parameter to constructor):
 // Bits 0,1 = R index (0-2), bits 2,3 = G index, bits 4,5 = B index

--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -28,6 +28,8 @@
 #include <pins_arduino.h>
 #endif
 
+#define PORTENTA_H7	// STM32H747xI
+
 // Color-order flag for LED pixels (optional extra parameter to constructor):
 // Bits 0,1 = R index (0-2), bits 2,3 = G index, bits 4,5 = B index
 #define DOTSTAR_RGB (0 | (1 << 2) | (2 << 4)) ///< Transmit as R,G,B

--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -18,7 +18,7 @@
  *
  */
 
-#ifndef _ADAFRUIT_DOT_STAR_H_
+#if !defined(_ADAFRUIT_DOT_STAR_H_)
 #define _ADAFRUIT_DOT_STAR_H_
 
 #if (ARDUINO >= 100)
@@ -198,7 +198,7 @@ private:
   uint8_t rOffset;    ///< Index of red in 3-byte pixel
   uint8_t gOffset;    ///< Index of green byte
   uint8_t bOffset;    ///< Index of blue byte
-#ifdef __AVR__
+#if defined(__AVR__)
   uint8_t dataPinMask;         ///< If soft SPI, data pin bitmask
   uint8_t clockPinMask;        ///< If soft SPI, clock pin bitmask
   volatile uint8_t *dataPort;  ///< If soft SPI, data PORT

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Adafruit DotStar [![Build Status](https://github.com/adafruit/Adafruit_DotStar/workflows/Arduino%20Library%20CI/badge.svg)](https://github.com/adafruit/Adafruit_DotStar/actions)
 
 Arduino library for controlling two-wire-based LED pixels and strips such as Adafruit DotStar LEDs and other APA102-compatible devices.
+
+Update:  This has been updated to work with the MKR-RGB Shield and the Portanta_H7.  A jumper must be placed from A3->A5.


### PR DESCRIPTION
Note - example in DotStarMatrix will demonstrate the changes - so, this in addition to the PR in the DotStarMatrix PR are necessary.

REQ: Please Add Support for the MRK-RGB Shield and the Portenta_H7. A jumper must be placed from A3->A5 when using the MRK-RGB shield on the Portenta H7.

List of changes:
The MRK-RGB shield has to used in 'bit-bang' mode to work on the Portenta H7 and one jumper must be added - the
A3 pin must be jumpered to A5. It's a relatively easy change to be able to use the shield on the H7. Yes, it's a one-off but
I must admit I like to use that shield on the H7. And, you can't have too many graphics libs, right?

In Adafruit_Dotstar.h:
added:
#define PORTENTA_H7 // STM32H747xI
In Adafruit_Dotstar.cpp:
added:
#ifndef PORTENTA_H7 'wrapper' to force use of software spi (a.k.a. bit-bang mode).

Readme.md:
Updated to summarize changes made.

To run as-is (before this update) - just comment out the
#define PORTENTA_H7 // STM32H747xI
in Adafruit_Dotstar.h.

This update is also demonstrated in a subsequent PR in the Adafruit_DotStarMatrix library:
..\examples\dotstar_wing\dotstar_win.ino has been updated to allow use of the MKR-RGB
shield on the Portenta H7.
The associated PR is here: [https://github.com/adafruit/Adafruit_DotStarMatrix/pull/6](https://github.com/adafruit/Adafruit_DotStarMatrix/pull/6)