### PR TITLE
Add Gemma M0 on board example

### DIFF
--- a/examples/GemmaM0Onboard/GemmaM0Onboard.ino
+++ b/examples/GemmaM0Onboard/GemmaM0Onboard.ino
@@ -1,0 +1,49 @@
+// An example demonstrating how to control the Adafruit Dot Star RGB LED
+// included on board the ItsyBitsy M4 board.
+
+#include <Adafruit_DotStar.h>
+
+// There is only one pixel on the board
+#define NUMPIXELS 1 
+
+//Use these pin definitions for the ItsyBitsy M4
+#define DATAPIN    8
+#define CLOCKPIN   6
+
+Adafruit_DotStar strip(NUMPIXELS, DATAPIN, CLOCKPIN, DOTSTAR_BRG);
+
+void setup() {
+  strip.begin(); // Initialize pins for output
+  strip.setBrightness(80);
+  strip.show();  // Turn all LEDs off ASAP
+}
+
+void loop() {
+  rainbow(10);             // Flowing rainbow cycle along the whole strip
+}
+
+
+
+// Rainbow cycle along whole strip. Pass delay time (in ms) between frames.
+void rainbow(int wait) {
+  // Hue of first pixel runs 5 complete loops through the color wheel.
+  // Color wheel has a range of 65536 but it's OK if we roll over, so
+  // just count from 0 to 5*65536. Adding 256 to firstPixelHue each time
+  // means we'll make 5*65536/256 = 1280 passes through this outer loop:
+  for(long firstPixelHue = 0; firstPixelHue < 5*65536; firstPixelHue += 256) {
+    for(int i=0; i<strip.numPixels(); i++) { // For each pixel in strip...
+      // Offset pixel hue by an amount to make one full revolution of the
+      // color wheel (range of 65536) along the length of the strip
+      // (strip.numPixels() steps):
+      int pixelHue = firstPixelHue + (i * 65536L / strip.numPixels());
+      // strip.ColorHSV() can take 1 or 3 arguments: a hue (0 to 65535) or
+      // optionally add saturation and value (brightness) (each 0 to 255).
+      // Here we're using just the single-argument hue variant. The result
+      // is passed through strip.gamma32() to provide 'truer' colors
+      // before assigning to each pixel:
+      strip.setPixelColor(i, strip.gamma32(strip.ColorHSV(pixelHue)));
+    }
+    strip.show(); // Update strip with new contents
+    delay(wait);  // Pause for a moment
+  }
+}


### PR DESCRIPTION
For #35. Adds a new dedicated Gemma M0 example for DotStar. The idea of using #defs is good, but would need to update several board headers to add and also would change name of existing example.

Tested on Gemma M0.