### PR TITLE
show: Use BusIO SPI transactions to set clock freq

### DIFF
--- a/Adafruit_DotStar.cpp
+++ b/Adafruit_DotStar.cpp
@@ -176,6 +176,9 @@ void Adafruit_DotStar::show(void) {
   uint16_t n = numLEDs;                // Counter
   uint16_t b16 = (uint16_t)brightness; // Type-convert for fixed-point math
 
+  // Begin transaction, setting SPI frequency
+  spi_dev->beginTransaction();
+
   // [START FRAME]
   for (i = 0; i < 4; i++)
     spi_dev->transfer(0x00);
@@ -207,6 +210,9 @@ void Adafruit_DotStar::show(void) {
   // https://cpldcpu.wordpress.com/2014/11/30/understanding-the-apa102-superled/
   for (i = 0; i < ((numLEDs + 15) / 16); i++)
     spi_dev->transfer(0xFF);
+
+  // Finish SPI transaction
+  spi_dev->endTransaction();
 }
 
 /*!


### PR DESCRIPTION
## In short
* Set hardware SPI speed to 8 MHz using `begin/endTransaction()`
  * 8 MHz is already specified with `new Adafruit_SPIDevice(-1, 8000000)`/etc
  * `Adafruit_SPIDevice` only applies this `freq` after calling `beginTransaction()`
  * Speeds up showing 300 DotStar LEDs by `1.2 ms` (from `3479 µs` to `2270 µs`)
* Hardware
  * [Adafruit ItsyBitsy M4 Express](https://www.adafruit.com/product/3800 )
  * 300 DotStar LEDs (2×[5m rolls](https://www.adafruit.com/product/2238?length=5 )) with the [SK9822 chipset](https://cdn-shop.adafruit.com/product-files/2238/SK9822SHIJI.pdf ), connected via [level shifter](https://www.adafruit.com/product/1787 ) to ItsyBitsy M4's `SCK` and `MO` pins
* Software
  * Arduino 1.8.19 IDE on Kubuntu 22.04 64-bit
  * [Adafruit DotStar library `1.2.0`](https://github.com/adafruit/Adafruit_DotStar/releases )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Makes DotStar LEDs even faster for persistence of vision/strobe/etc
Risk | ★★☆ *2/3* | Applying higher speed may introduce instability
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Details

The BusIO update in Adafruit_DotStar v1.2.0 specified 8 MHz as the desired SPI frequency.  However, it overlooked the need to begin and end transactions on the `Adafruit_SPIDevice` in order to actually apply this frequency and ensure the settings are correct after any unrelated SPI transactions to other devices.

Alternatively, if avoiding the use of SPI transactions is intentional (e.g. to allow others to customize the SPI frequency before/after calling `show()`), the DotStar library code should probably have a comment to explain this.

## Testing
### Steps
1.  Fetch the DotStar library, with or without patches
2.  Compile and upload the following `strandtest_perf.ino` code
3.  Observe the Arduino serial monitor
4.  Verify LEDs function correctly with no flickering or glitching near the end

### Before
Average of `3479 µs` delay to update 300 DotStar LEDs.

### After
Average of `2270 µs` delay to update 300 DotStar LEDs.

### Example code

**`strandtest_perf.ino`**

```cpp
// Simple strand test for Adafruit Dot Star RGB LED strip.
// Mostly copied from https://github.com/adafruit/Adafruit_DotStar/blob/master/examples/strandtest/strandtest.ino
// Includes commands to measure timing of updating LED strand

#include <Adafruit_DotStar.h>

// For testing: 300 DotStar pixels
#define NUMPIXELS 300 // Number of LEDs in strip

// For testing: hardware SPI
Adafruit_DotStar strip(NUMPIXELS, DOTSTAR_BGR);

void setup() {
  Serial.begin(115200);     // Initialize to fastest common baud rate

  strip.begin();            // Initialize pins for output
  strip.show();             // Turn all LEDs off ASAP
}

// Runs 10 LEDs at a time along strip, cycling through red, green and blue.

int      head  = 0, tail = -10; // Index of first 'on' and 'off' pixels
uint32_t color = 0xFF0000;      // 'On' color (starts red)

void loop() {
  strip.setPixelColor(head, color); // 'On' pixel at head
  strip.setPixelColor(tail, 0);     // 'Off' pixel at tail

  unsigned long start = micros();   // Track start time
  strip.show();                     // Refresh strip
  Serial.println(micros() - start); // Print time taken

  delay(20);                        // Pause 20 milliseconds (~50 FPS)

  if(++head >= NUMPIXELS) {         // Increment head index.  Off end of strip?
    head = 0;                       //  Yes, reset head index to start
    if((color >>= 8) == 0)          //  Next color (R->G->B) ... past blue now?
      color = 0xFF0000;             //   Yes, reset to red
  }
  if(++tail >= NUMPIXELS) tail = 0; // Increment, reset tail index
}
```
