### PR TITLE
Fix HW SPI preprocessor check

### DIFF
--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -102,7 +102,7 @@ class Adafruit_DotStar {
 
 public:
 #if !defined(SPI_INTERFACES_COUNT) ||                                          \
-  (defined(SPI_INTERFACES_COUNT) && (SPI_INTERFACES_COUNT > 0))
+    (defined(SPI_INTERFACES_COUNT) && (SPI_INTERFACES_COUNT > 0))
   // HW SPI available
   Adafruit_DotStar(uint16_t n, uint8_t o = DOTSTAR_BRG, SPIClass *spi = &SPI);
 #else

--- a/Adafruit_DotStar.h
+++ b/Adafruit_DotStar.h
@@ -101,7 +101,9 @@ static const uint8_t PROGMEM _DotStarGammaTable[256] = {
 class Adafruit_DotStar {
 
 public:
-#if defined SPI // Is a default hardware SPI device defined for this board?
+#if !defined(SPI_INTERFACES_COUNT) ||                                          \
+  (defined(SPI_INTERFACES_COUNT) && (SPI_INTERFACES_COUNT > 0))
+  // HW SPI available
   Adafruit_DotStar(uint16_t n, uint8_t o = DOTSTAR_BRG, SPIClass *spi = &SPI);
 #else
   Adafruit_DotStar(uint16_t n, uint8_t o = DOTSTAR_BRG, SPIClass *spi = NULL);


### PR DESCRIPTION
Fixes #54.

Reuses the same HW SPI pre processor check logic from BusIO:
https://github.com/adafruit/Adafruit_BusIO/blob/186bfb005c6d4b597a09290cb3e451c30a5baa97/Adafruit_SPIDevice.h#L6-L7 

Tested with an Itsy M4 and a DotStar strand on HW SPI pins SCK and MOSI.

```cpp
#include <Adafruit_DotStar.h>

#define NUMPIXELS 10

Adafruit_DotStar strip(NUMPIXELS, DOTSTAR_BGR);

void setup() {
  strip.begin();
  strip.fill(0xFF0000);
  strip.show();
  delay(1000);
  strip.fill(0x00FF00);
  strip.show();
  delay(1000);
  strip.fill(0x0000FF);
  strip.show();
  delay(1000);
}

void loop() {
}
```